### PR TITLE
allow to pass time as number or date as well

### DIFF
--- a/TimeAgo.js
+++ b/TimeAgo.js
@@ -9,7 +9,7 @@ var TimerMixin = require('react-timer-mixin');
 var TimeAgo = React.createClass({
   mixins: [TimerMixin],
   propTypes: {
-    time: PropTypes.string.isRequired,
+    time: PropTypes.any.isRequired,
     interval: PropTypes.number,
     hideAgo: PropTypes.bool
   },


### PR DESCRIPTION
I opt for flexibility, as passing only string as time does not guarantee that it is valid time.
